### PR TITLE
Detector documentation

### DIFF
--- a/CBC_Simulation.py
+++ b/CBC_Simulation.py
@@ -8,6 +8,8 @@ from numpy.random import default_rng
 import time
 import json
 
+from itertools import combinations, chain
+
 from tqdm import tqdm
 from astropy.cosmology import FlatLambdaCDM
 
@@ -18,6 +20,10 @@ import GWFish.modules as gw
 cosmo = FlatLambdaCDM(H0=69.6, Om0=0.286)
 
 rng = default_rng()
+
+def powerset(length):
+    it = chain.from_iterable((combinations(range(length), r)) for r in range(length+1))
+    return list(it)[1:]
 
 def main():
     # example to run with command-line arguments:
@@ -56,7 +62,11 @@ def main():
     population = args.pop_id
 
     detectors_ids = args.detectors
-    networks_ids = json.loads(args.networks)
+    
+    if args.networks == 'all':
+        networks_ids = powerset(len(detectors_ids))
+    else:
+        networks_ids = json.loads(args.networks)
 
     parameters = pd.read_hdf(pop_file)
 

--- a/CBC_Simulation.py
+++ b/CBC_Simulation.py
@@ -42,11 +42,13 @@ def main():
         help='Detectors to analyze. Uses ET as default if no argument given.')
     parser.add_argument(
         '--networks', default=['[[0]]'],
-        help='Network IDs. Uses [[0]] as default if no argument given.')
+        help='''Network IDs: list of lists of detector IDs. 
+Uses [[0]] (only the first detector) as default if no argument given.
+Use "all" to get all possible combinations of the detectors given.''')
     parser.add_argument(
         '--config', type=str, default='GWFish/detectors.yaml',
         help='Configuration file where the detector specifications are stored. Uses GWFish/detectors.yaml as default if no argument given.')
-   
+    
 
     args = parser.parse_args()
     ConfigDet = args.config

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,6 +59,12 @@ exclude_patterns = []
 #
 html_theme = 'furo'
 
+html_theme_options = {
+    "source_repository": "https://github.com/janosch314/GWFish",
+    "source_branch": "main",
+    "source_directory": "docs/",
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/source/explanation/fisher_matrix.md
+++ b/docs/source/explanation/fisher_matrix.md
@@ -3,14 +3,14 @@
 The estimates in GWFish are obtained by considering a quadratic approximation to the likelihood 
 (valid in the high-SNR limit), in the form 
 
-$$ \mathcal{L} \propto \exp \left( - \frac{1}{2} \Delta \theta ^i \Gamma_{ij} \Delta \theta ^j \right)
+$$ \mathcal{L} \propto \exp \left( - \frac{1}{2} \Delta \theta ^i \mathcal{F}_{ij} \Delta \theta ^j \right)
 $$
 
 where $\Delta \theta = \theta - \overline{\theta}$ is the vector of the errors in our
 estimates for the parameters, $\overline{\theta}$ being the vector of the true values.
 The matrix $\Gamma$ is computed as 
 
-$$\Gamma_{ij} = 
+$$\mathcal{F}_{ij} = 
 \left( 
     \frac{\partial h}{\partial \theta _i} 
     \left| 
@@ -18,18 +18,26 @@ $$\Gamma_{ij} =
 \right.\right)
 $$
 
-where $h$ is the strain at the detector corresponding to the parameters $\theta$,
-the product denoted as $(h|g)$ is 
+Here $h = h(f)$ is the frequency-domain strain at the detector corresponding to the parameters $\theta$:
+
+$$ h(f) = h_{ab} (f) \mathcal{A}_{ab}(t(f))
+$$
+
+where $\mathcal{A}$ is the time-dependent response matrix of our detector, $t(f)$ is the time at which
+the component of the signal at frequency $f$ is measured, and $h_{ab}(f)$ is the frequency-domain 
+metric perturbation.
+
+The product denoted as $(h|g)$ is the noise-weighted Wiener product:
 
 $$ (h | g) = 4 \Re \int_0^{ \infty } \mathrm{d}f \frac{h^* (f) g(f)}{S_n(f)}\,,
 $$
 
 $S_n$ being the power spectral density of the noise.
 
-The covariance matrix is therefore the inverse of $\Gamma _{ij}$, and the variance
+The covariance matrix is therefore the inverse of $\mathcal{F} _{ij}$, and the variance
 of each parameter can be computed as 
 
-$$ \operatorname{var} \theta _i = (\Gamma^{-1})_{ii}
+$$ \operatorname{var} \theta _i = (\mathcal{F}^{-1})_{ii}
 $$
 
 where no summation is intended.
@@ -39,7 +47,7 @@ in the direction of a specific parameter, that parameter will be hard to constra
 ## Computational challenges
 
 One of the most difficult steps in the computation outlined above is the inversion of the 
-matrix $\Gamma$, not because of its high dimensionality (it's on the order of $10\times 10$)
+matrix $\mathcal{F}$, not because of its high dimensionality (it's on the order of $10\times 10$)
 but because it is prone to having singular rows/columns.
 
 For example, consider a system seen head-on (observation direction aligned 

--- a/docs/source/how-to/adding_new_detectors.md
+++ b/docs/source/how-to/adding_new_detectors.md
@@ -2,17 +2,15 @@
 
 Adding a new detector to GWFish is relatively straightforward, as long as it
 is in the same class as an existing one. 
+Let us suppose the detector you want to add falls into one of the 
+{ref}`existing categories <reference/detectors:Detector properties>`.
 
-The detector class can currently be one of the following:
+Modify the `GWFish/detectors.yaml` file, adding an entry 
+for the new detector's parameters, and if needed add its PSD to 
+the `GWFish/detector_psd` folder. 
+Refer to the {ref}`detector documentation <reference/detectors:Detector properties>` for the 
+conventions on how to format these parameters.
 
-- `earthDelta` (e.g. Einstein Telescope)
-- `earthL` (e.g. LIGO, Virgo, Cosmic Explorer)
-- `satellitesolarorbit` (e.g. LISA)
-- `lunararray` (e.g. LGWA)
-
-Let us suppose the detector we want to add falls into one of these categories.
-The way to add it, then, is to modify the `GWFish/detectors.yaml` file.
-
-```{todo}
-This how-to guide is unfinished.
-```
+Remember to give the new detector a unique identifier.
+Now, it will be possible to refer to this detector when calling the 
+{ref}`simulation script <tutorials/tutorial_170817:Simulation>`.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -22,7 +22,8 @@ For more information about the theory than what is discussed here, refer to
 the __[`GWFish` paper](https://arxiv.org/abs/2205.02499)__ (preprint, submitted to 
 [Astronomy and Computing](https://www.journals.elsevier.com/astronomy-and-computing)).
 
-This software is developed by the gravitation group at the [Gran Sasso Science Institute](https://www.gssi.it/).
+This software is developed by the [gravitation group](https://wikiet.gssi.it/index.php/Main_Page) 
+at the [Gran Sasso Science Institute](https://www.gssi.it/).
 
 ```{seealso}
 This documentation is written according to the [diátaxis framework](https://diataxis.fr).

--- a/docs/source/reference/detectors.md
+++ b/docs/source/reference/detectors.md
@@ -1,0 +1,48 @@
+# Detectors
+
+## Detector classes
+
+The currently supported detector classes are the following:
+
+- `earthDelta` (e.g. Einstein Telescope);
+- `earthL` (e.g. LIGO, Virgo, Cosmic Explorer);
+- `satellitesolarorbit` (e.g. LISA);
+- `lunararray` (e.g. LGWA).
+
+## Detector properties
+
+The properties of each detector are specified in the `GWFish/detectors.yaml` file.
+These are strings which will be parsed through an `eval`, so they can include any 
+valid `python` expression. The type denoted in parentheses is the one they must be able
+to be evaluated into (e.g. `'1e-1*np.pi'` evaluates to a floating point number $\approx 0.314$).
+
+__All detectors__ require:
+
+- __`detector_class`__ (`str`): one of the four aforementioned classes;
+- __`fmin`, `fmax`, `df`__ (`float`): minimum and maximum frequency, and frequency spacing 
+    (all in Hz): 
+    the frequency array is determined by these parameters;
+- __`duty_factor`__ (`float` between 0 and 1): the fraction of time the detector is expected to be on for;
+- __`plotrange`__ (`tuple` of four `float`s, representing `fmin`, `fmax`, `strain_min`, `strain_max`): 
+    x and y limits of a plot of the detector's characteristic noise strain.
+
+__Non-space-based__ `earthDelta`, `earthL` and `lunararray`-type detectors all require:
+
+- __`lat`__ and __`lon`__ (`float`): coordinates of the detector on the surface of the body (Earth/Moon), in radians;
+- __`azimuth`__ (`float`): azimuthal angle of the arms, in radians --- for a lunar array, this instead means (???)
+- __`psd_data`__ (`str` which is a valid file path): location of a space-separated text file, typically within 
+    the folder `GWFish/psd_data/`, containing two columns: frequency (in Hz) and PSD value (in $\text{Hz}^{-1}$).
+
+```{todo}
+Unclear meaning of azimuth in the lunar array case --- it likely is the angle
+between two of the seismometers, but I'd like to make sure of this.
+```
+
+__Earth-bound__ `earthDelta` and `earthL`-type detectors require:
+
+- __`opening_angle`__ (`float`): angle between the detector arms, in radians 
+    (should be $\pi/3$ for the triangle, $\pi/2$ for the L);
+
+__Non-Earth-bound__ `lunararray` and `satellitesolarorbit`-type detectors require:
+
+- __`mission_lifetime`__ (`float`): expected mission duration, in seconds.

--- a/docs/source/tutorials/tutorial_170817.md
+++ b/docs/source/tutorials/tutorial_170817.md
@@ -94,9 +94,21 @@ SNR: 720.575 (min) , 720.575 (max)
 ```{admonition} Which detectors are available?
 :class: seealso
 
-The full list of available options, as well as more details on these detectors, 
+The full list of available options, as well as more details on these detectors,
 can be found in `GWFish/detectors.yaml`.
+The syntax for this file is detailed {ref}`here <reference/detectors:Detectors>`.
+If you want to add a new detector, 
+see {ref}`here <how-to/adding_new_detectors:How to add a new detector to GWFish>`.
 ```
+
+```{note}
+More detail on the syntax of the `CBC_Simulation.py` script can be gotten 
+by running
+
+```python
+python CBC_Simulation.py --help
+```
+
 
 ## Results
 


### PR DESCRIPTION
In this PR: 

- a new "all" option for the network IDs when running `CBC_Simulation`
- a reference for the detector parameters 
- a quick how-to on how to add a new detector
- fixing the edit button on readthedocs