### PR TITLE
Return detected indices

### DIFF
--- a/docs/source/tutorials/tutorial_170817.md
+++ b/docs/source/tutorials/tutorial_170817.md
@@ -60,7 +60,7 @@ Once we have this population dictionary, we can compute the required errors by d
     
 >>> network = Network(['ET', 'CE1', 'CE2'])
 
->>> snr, errors, sky_localization = compute_network_errors(
+>>> detected, snr, errors, sky_localization = compute_network_errors(
 ...    network, 
 ...    parameters, 
 ...    waveform_model='IMRPhenomD_NRTidalv2'

--- a/docs/source/tutorials/tutorial_randomization.md
+++ b/docs/source/tutorials/tutorial_randomization.md
@@ -67,11 +67,15 @@ Fisher matrix errors just like discussed in the
     
 >>> network = Network(['ET', 'CE1', 'CE2'])
 
->>> snr, errors, sky_localization = compute_network_errors(
+>>> detected, snr, errors, sky_localization = compute_network_errors(
 ...    network, 
 ...    parameters, 
 ...    waveform_model='IMRPhenomD_NRTidalv2'
 ... )
+
+>>> snr = snr[detected]
+>>> errors = errors[detected, :]
+>>> sky_localization = sky_localization[detected]
 
 ```
 

--- a/tests/test_fisher_output.py
+++ b/tests/test_fisher_output.py
@@ -12,12 +12,12 @@ from GWFish.modules.fishermatrix import (analyze_and_save_to_txt,
 
 BASE_PATH = Path(__file__).parent.parent
 
-@pytest.mark.skip('Takes a long time and still does not check anything')
+# @pytest.mark.skip('Takes a long time and still does not check anything')
 def test_gwtc3_catalog_results(plot):
     params = pd.read_hdf(BASE_PATH / 'injections/GWTC3_cosmo_median.hdf5')
     
     z = params['redshift'].copy()
-    params.drop('redshift')
+    params = params.drop(['event_ID'], axis=1)
     params.loc[:, 'mass_1'] = params['mass_1'].to_numpy() * (1+z)
     params.loc[:, 'mass_2'] = params['mass_2'].to_numpy() * (1+z)
     
@@ -35,14 +35,16 @@ def test_gwtc3_catalog_results(plot):
         'a_2', 
     ]
 
-    network = Network(['LLO', 'LHO', 'VIR'], detection_SNR=(0., 1.))
+    network = Network(['LLO', 'LHO', 'VIR'], detection_SNR=(0., 25.))
 
-    network_snr, parameter_errors, sky_localization = compute_network_errors(
-        network,
-        params,
-        fisher_parameters=fisher_params, 
-        waveform_model='IMRPhenomXPHM'
-    )
+    # network_snr, parameter_errors, sky_localization = compute_network_errors(
+    #     network,
+    #     params.iloc[:5],
+    #     fisher_parameters=fisher_params, 
+    #     waveform_model='IMRPhenomXPHM'
+    # )
+    
+    analyze_and_save_to_txt(network, params.iloc[:5], fisher_params, [[0, 1, 2]], 'GWTC3', save_matrices=False, waveform_model='IMRPhenomXPHM')
     
     # TODO: assert correctness based on catalog results
 
@@ -81,7 +83,7 @@ def test_gw190521_full_fisher(plot):
     
     network = Network(['LGWA'], detection_SNR=(0., 1.))
     
-    network_snr, parameter_errors, sky_localization = compute_network_errors(
+    detected, network_snr, parameter_errors, sky_localization = compute_network_errors(
         network,
         params,
         fisher_parameters=fisher_params, 

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -35,7 +35,7 @@ def test_gw170817_localization(gw170817_params):
     
     network = Network(['LGWA'])
     
-    network_snr, parameter_errors, sky_localization = compute_network_errors(
+    detected, network_snr, parameter_errors, sky_localization = compute_network_errors(
         network,
         gw170817_params,
         fisher_parameters=list(gw170817_params.keys()),


### PR DESCRIPTION
Change the signature of `compute_fisher_errors` to 

```python
detected, snr, errors, sky_localization = compute_network_errors(...)
```
where `detected` is an array of indices for the detected signals, while `snr` and the other return values contain _all_ the signals, even the ones that were not detected.

This solves a bug with the saving of the data in cases where not all signals are detected.