### PR TITLE
Response at high frequency for ground-based detectors

### DIFF
--- a/GWFish/detectors.yaml
+++ b/GWFish/detectors.yaml
@@ -12,6 +12,8 @@ ET:
             spacing:          geometric
             df:               1./16.
             npoints:          1000
+            arm_length:       10000.
+            
 VOY:
             lat:              46.5 * np.pi / 180.
             lon:              -119.4 * np.pi / 180.


### PR DESCRIPTION
Changes inside detection.py and detector.yaml to include the possibility to avoid the long wavelength approximation. Inside detection.py, I added the possibility to read the arm length to compute f_c = c/(2 pi L). Then, I added the Michelson transfer function and finally, when long_wavelength_approx = True, you can modify the projection in the Earth case including the response at high frequencies.