### PR TITLE
'settingwithcopywarning' warning from pandas

### DIFF
--- a/GWFish/modules/auxiliary.py
+++ b/GWFish/modules/auxiliary.py
@@ -26,22 +26,23 @@ def check_and_convert_to_mass_1_mass_2(parameters):
 
     lalsim requires individual masses in detector frame, whenever required, convert to m1, m2
     """
-    if ('chirp_mass' in parameters.keys()) and ('mass_ratio' in parameters.keys()):
-            parameters['mass_1'], parameters['mass_2'] = from_mChirp_q_to_m1_m2(parameters['chirp_mass'], parameters['mass_ratio'])
-    if ('chirp_mass_source' in parameters.keys()) and ('mass_ratio' in parameters.keys()):
+    local_params = parameters.copy() 
+    if ('chirp_mass' in local_params.keys()) and ('mass_ratio' in local_params.keys()):
+            local_params['mass_1'], local_params['mass_2'] = from_mChirp_q_to_m1_m2(local_params['chirp_mass'], local_params['mass_ratio'])
+    if ('chirp_mass_source' in local_params.keys()) and ('mass_ratio' in local_params.keys()):
         if 'redshift' not in parameters.keys():
+                raise ValueError('If using source-frame masses, one must specify the redshift parameter')
+        else:
+            local_params['mass_1_source'], local_params['mass_2_source'] = from_mChirp_q_to_m1_m2(local_params['chirp_mass_source'], local_params['mass_ratio'])
+            local_params['mass_1'] = local_params['mass_1_source'] * (1 + local_params['redshift'])
+            local_params['mass_2'] = local_params['mass_2_source'] * (1 + local_params['redshift'])
+    if ('mass_1_source' in local_params.keys()) or ('mass_2_source' in local_params.keys()):
+        if 'redshift' not in local_params.keys():
             raise ValueError('If using source-frame masses, one must specify the redshift parameter')
         else:
-            parameters['mass_1_source'], parameters['mass_2_source'] = from_mChirp_q_to_m1_m2(parameters['chirp_mass_source'], parameters['mass_ratio'])
-            parameters['mass_1'] = parameters['mass_1_source'] * (1 + parameters['redshift'])
-            parameters['mass_2'] = parameters['mass_2_source'] * (1 + parameters['redshift'])
-    if ('mass_1_source' in parameters.keys()) or ('mass_2_source' in parameters.keys()):
-        if 'redshift' not in parameters.keys():
-            raise ValueError('If using source-frame masses, one must specify the redshift parameter')
-        else:
-            parameters['mass_1'] = parameters['mass_1_source'] * (1 + parameters['redshift'])
-            parameters['mass_2'] = parameters['mass_2_source'] * (1 + parameters['redshift'])
-
+            local_params['mass_1'] = local_params['mass_1_source'] * (1 + local_params['redshift'])
+            local_params['mass_2'] = local_params['mass_2_source'] * (1 + local_params['redshift'])
+    return local_params
 
 def fisco(parameters):
     """

--- a/GWFish/modules/waveforms.py
+++ b/GWFish/modules/waveforms.py
@@ -92,7 +92,7 @@ def t_of_f_PN(parameters, frequencyvector):
     term, which does not matter for SNR calculations.
     """
     local_params = parameters.copy()
-    aux.check_and_convert_to_mass_1_mass_2(local_params)
+    local_params = aux.check_and_convert_to_mass_1_mass_2(local_params)
 
     M1 = local_params['mass_1'] * cst.Msol
     M2 = local_params['mass_2'] * cst.Msol
@@ -109,7 +109,7 @@ def t_of_f_PN(parameters, frequencyvector):
 
 class Waveform:
     def __init__(self, name, gw_params, data_params):
-        aux.check_and_convert_to_mass_1_mass_2(gw_params)
+        gw_params = aux.check_and_convert_to_mass_1_mass_2(gw_params)
         self.name = name
         self._set_default_gw_params()
         self.gw_params.update(gw_params)


### PR DESCRIPTION
Whenever the `check_and_convert_to_mass_1_mass_2` function was called because of the injected parameters being chirp_mass and mass_ratio, it showed the following warning:

```/scratch/prasad_subramanian/harshal/python_packages/GWFish-1/GWFish/modules/auxiliary.py:30: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  parameters['mass_1'], parameters['mass_2'] = from_mChirp_q_to_m1_m2(parameters['chirp_mass'], parameters['mass_ratio'])
```

So in the function `check_and_convert_to_mass_1_mass_2`, I created a copy of the parameters and accordingly did 2 changes in `waveforms.py`.