### PR TITLE
Added eta to input parameters and reduced derivative step size for chirp mass

### DIFF
--- a/GWFish/modules/auxiliary.py
+++ b/GWFish/modules/auxiliary.py
@@ -16,11 +16,24 @@ def from_mChirp_q_to_m1_m2(mChirp, q):
     
     return m1, m2
 
+
+def from_mChirp_eta_to_m1_m2(mChirp, eta):
+    """
+    Compute the transformation from mChirp, eta to m1, m2
+    """
+    m1 = mChirp * (1 + np.sqrt(1 - 4 * eta)) / 2 * eta**(-3/5)
+    m2 = mChirp * (1 - np.sqrt(1 - 4 * eta)) / 2 * eta**(-3/5)
+    
+    return m1, m2
+
+
 def check_and_convert_to_mass_1_mass_2(parameters):
     """
     GWFish accepts different combinations of mass inputs:
     - chirp_mass, mass_ratio
+    - chirp_mass, eta
     - chirp_mass_source, mass_ratio, redshift
+    - chirp_mass_source, eta, redshift
     - mass_1_source, mass_2_source, redshift
     - mass_1, mass_2
 
@@ -29,11 +42,20 @@ def check_and_convert_to_mass_1_mass_2(parameters):
     local_params = parameters.copy() 
     if ('chirp_mass' in local_params.keys()) and ('mass_ratio' in local_params.keys()):
             local_params['mass_1'], local_params['mass_2'] = from_mChirp_q_to_m1_m2(local_params['chirp_mass'], local_params['mass_ratio'])
+    if ('chirp_mass' in local_params.keys()) and ('eta' in local_params.keys()):
+            local_params['mass_1'], local_params['mass_2'] = from_mChirp_eta_to_m1_m2(local_params['chirp_mass'], local_params['eta'])
     if ('chirp_mass_source' in local_params.keys()) and ('mass_ratio' in local_params.keys()):
         if 'redshift' not in parameters.keys():
                 raise ValueError('If using source-frame masses, one must specify the redshift parameter')
         else:
             local_params['mass_1_source'], local_params['mass_2_source'] = from_mChirp_q_to_m1_m2(local_params['chirp_mass_source'], local_params['mass_ratio'])
+            local_params['mass_1'] = local_params['mass_1_source'] * (1 + local_params['redshift'])
+            local_params['mass_2'] = local_params['mass_2_source'] * (1 + local_params['redshift'])
+    if ('chirp_mass_source' in local_params.keys()) and ('eta' in local_params.keys()):
+        if 'redshift' not in parameters.keys():
+                raise ValueError('If using source-frame masses, one must specify the redshift parameter')
+        else:
+            local_params['mass_1_source'], local_params['mass_2_source'] = from_mChirp_eta_to_m1_m2(local_params['chirp_mass_source'], local_params['eta'])
             local_params['mass_1'] = local_params['mass_1_source'] * (1 + local_params['redshift'])
             local_params['mass_2'] = local_params['mass_2_source'] * (1 + local_params['redshift'])
     if ('mass_1_source' in local_params.keys()) or ('mass_2_source' in local_params.keys()):

--- a/GWFish/modules/fishermatrix.py
+++ b/GWFish/modules/fishermatrix.py
@@ -115,7 +115,7 @@ class Derivative:
         else:
             pv = self.local_params[target_parameter]
 
-            if target_parameter == 'chirp_mass':
+            if target_parameter in ['chirp_mass', 'chirp_mass_source', 'mass_1', 'mass_2', 'mass_1_source', 'mass_2_source']:
                 dp = 1e-8 * pv
             else:
                 dp = np.maximum(self.eps, self.eps * pv)

--- a/GWFish/modules/fishermatrix.py
+++ b/GWFish/modules/fishermatrix.py
@@ -116,7 +116,7 @@ class Derivative:
             pv = self.local_params[target_parameter]
 
             if target_parameter == 'chirp_mass':
-                dp = 1e-8
+                dp = 1e-8 * pv
             else:
                 dp = np.maximum(self.eps, self.eps * pv)
 

--- a/GWFish/modules/fishermatrix.py
+++ b/GWFish/modules/fishermatrix.py
@@ -115,7 +115,10 @@ class Derivative:
         else:
             pv = self.local_params[target_parameter]
 
-            dp = np.maximum(self.eps, self.eps * pv)
+            if target_parameter == 'chirp_mass':
+                dp = 1e-8
+            else:
+                dp = np.maximum(self.eps, self.eps * pv)
 
             self.pv_set1 = self.local_params.copy()
             self.pv_set2 = self.local_params.copy()

--- a/docs/source/tutorials/tutorial_170817.md
+++ b/docs/source/tutorials/tutorial_170817.md
@@ -105,15 +105,15 @@ The `errors` array contains the one-sigma errors for all the parameters included
 ```python
 >>> for name, error in zip(parameters.keys(), errors[0]):
 ...     print(f'{name}: {error:.2e}') 
-mass_1: 1.30e-04
-mass_2: 1.20e-04
-luminosity_distance: 6.38e+01
-theta_jn: 2.77e-01
+mass_1: 2.32e-03
+mass_2: 2.13e-03
+luminosity_distance: 6.41e+01
+theta_jn: 2.79e-01
 ra: 9.76e-03
-dec: 4.72e-03
-psi: 7.17e-01
+dec: 4.73e-03
+psi: 7.15e-01
 phase: 1.44e+00
-geocent_time: 2.69e-05
+geocent_time: 2.88e-05
 
 ```
 
@@ -124,9 +124,9 @@ The sky localization error is given separately:
 ```python
 >>> from GWFish.modules.fishermatrix import sky_localization_percentile_factor
 >>> print(f'{sky_localization[0]:.2e}')
-6.65e-05
+6.66e-05
 >>> print(f'{sky_localization[0] * sky_localization_percentile_factor():.2e}')
-1.00e+00
+1.01e+00
 
 ```
 

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -44,5 +44,5 @@ def test_gw170817_localization(gw170817_params):
 
     skyloc_arcmin_square = sky_localization * sky_localization_percentile_factor(90.) * 60**2
     
-    assert np.isclose(skyloc_arcmin_square, 3, rtol=0.2)
+    assert np.isclose(skyloc_arcmin_square, 3.8, rtol=0.2)
     


### PR DESCRIPTION
There are two updates:
1. Possibility to pass chirp mass and symmetric mass ratio (eta) as input parameters for masses 
2. Reduction of derivative step size for the chirp mass; the error on the chirp mass might be much smaller than the current step size used to calculate the derivative (eps=1e-5). Tests show that eps=1e-8 for the chirp mass derivative falls in the stability interval for the derivative results; the derivative on chirp mass correlates with spins as well

![eps_error_relation](https://github.com/user-attachments/assets/fb92b8b7-fc92-46ae-bc5c-dbcf2438439e)



