### PR TITLE
avoid crushing when duty cycle turns off the whole network

### DIFF
--- a/GWFish/modules/fishermatrix.py
+++ b/GWFish/modules/fishermatrix.py
@@ -401,8 +401,10 @@ def compute_network_errors(
         
             if np.sqrt(detector_snr_square) > detector_snr_thr:
                 network_fisher_matrix += detector_fisher
-
-        network_fisher_inverse, _ = invertSVD(network_fisher_matrix)
+        if network_snr_square == 0.:
+            continue
+        else:
+            network_fisher_inverse, _ = invertSVD(network_fisher_matrix)
         
         if save_matrices:
             fisher_matrices[k, :, :] = network_fisher_matrix


### PR DESCRIPTION
In fishermatrix.py, if use_duty_cycle=True and it happens that the whole network is off, the code tries to invert a zero Fisher matrix, and everything crashes. Added a check to control if network_snr_square is zero (so that inversion is not performed). In any case, everything is then filtered with the detected variable, and the zero-valued matrices and param_errors are not considered.